### PR TITLE
refactor: Correct spelling error in method name

### DIFF
--- a/src/dota2drafter/Global.java
+++ b/src/dota2drafter/Global.java
@@ -41,7 +41,7 @@ public class Global {
     public static String PLAYER_PATH = (Global.class.getProtectionDomain().getCodeSource().getLocation().getPath()).replaceAll("dota2drafter\\.jar", "").replaceAll("/C", "C") + "/Players/";
     public static String EMERGENCY_PLAYER_PATH = ("C:/Dota2Drafter/Players/");
 
-    public static boolean ExsistsInPool(String find, Hero[] heroes) {
+    public static boolean existsInPool(String find, Hero[] heroes) {
         // Null check everything before moving on
         if (heroes == null) {
             return false;

--- a/src/dota2drafter/Team.java
+++ b/src/dota2drafter/Team.java
@@ -86,7 +86,7 @@ public class Team {
     
     void AddToPool(Hero hero) {
         // Don't want duplicates
-        if (!Global.ExsistsInPool(hero.abbrv, GetHeroPool()) && poolNumber < Global.NUMBER_OF_HEROES) {
+        if (!Global.existsInPool(hero.abbrv, GetHeroPool()) && poolNumber < Global.NUMBER_OF_HEROES) {
            AddHero(hero); 
         }
     }

--- a/src/dota2drafter/WindowManager.java
+++ b/src/dota2drafter/WindowManager.java
@@ -849,7 +849,7 @@ public class WindowManager {
                 JLabel label = new JLabel(hero.portraitSmall);
                 heroPanels.get(hero.side + hero.attribute).add(label);
                 // Disable the button if the hero it contains matches the disableList.
-                if (Global.ExsistsInPool(hero.abbrv, disableList)) {
+                if (Global.existsInPool(hero.abbrv, disableList)) {
                     label.setEnabled(false);
                 } else {
                     label.addMouseListener(new MouseAdapter() {


### PR DESCRIPTION
As far as I can tell this method isn't ever called in this version of the code, so the name change shouldn't break anything. While I was at it, I also changed the name to start with a lowercase letter to match standard method naming convention.
