### PR TITLE
fix: Correct spelling of string param

### DIFF
--- a/src/dota2drafter/WindowManager.java
+++ b/src/dota2drafter/WindowManager.java
@@ -327,7 +327,7 @@ public class WindowManager {
                     players.add(heroes);
                 }
             }
-            enemyPool = new PoolBuilder(false, "samll", new returner(), null);
+            enemyPool = new PoolBuilder(false, "small", new returner(), null);
             theirPool.add(enemyPool.pool);
             
             Eve.add(matchup, "span, grow");


### PR DESCRIPTION
It should be noted however that currently the implementation of this method
doesn't even do anything with this parameter. This needs to be fixed in the
future and also explains why this misspelling hasn't yet caused any errors.
